### PR TITLE
Add Himalayas as a remote job site

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Notes:
 * [AngelList remote job collection](https://angel.co/job-collections/remote)
 * [Authentic Jobs](https://authenticjobs.com/#onlyremote=1)
 * [FlexJobs](https://www.flexjobs.com/)
+* [Himalayas](https://himalayas.app)
 * [NODESK](https://nodesk.co/remote-jobs/)
 * [Remote4me](https://remote4me.com/)
 * [RemoteBase](https://remotebase.com/)


### PR DESCRIPTION
Added https://himalayas.app/ as a remote job board resource for security jobs.

Himalayas is a remote job board that offers a large range of remote-specific filters, jobs, and company profiles, including information about company tech stacks and benefits. It is free for job seekers to use to find remote jobs.

To satisfy the traffic requirements, Himalayas has a higher Alexa rank than RemoteBase, Remote4me and Authentic Jobs, and is in active full-time development.