### PR TITLE
Remove Stack Overflow Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Notes:
 * [Remote.co](https://remote.co/remote-jobs/)
 * [Remote | OK](https://remoteok.io/)
 * [Remotive](http://jobs.remotive.io/)
-* [Stack Overflow remote job listings](https://stackoverflow.com/jobs?allowsremote=true)
 * [WeWorkRemotely](https://weworkremotely.com/)
 * [Working Nomads](http://www.workingnomads.co/jobs)
 


### PR DESCRIPTION
"We have shut down Stack Overflow Jobs and Developer Story as of April 1, 2022" https://stackoverflow.com/jobs?allowsremote=true

<!--
Thank you for your contribution!
We love to see more remote companies, but we keep the list curated.
Please use the checklist to verify that the proposed company matches the current criteria.
-->

## Checklist

- [N/A] The company has at least 50 employees
- [N/A] The company has multiple open positions that require programming skills
- [N/A] The company is hiring globally (i.e., not limited by timezone or to rich countries)
