### PR TITLE
Replaced an irrelevant link with an actual remote job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Notes:
 
 ## Remote job search websites
 
+* [Real Work From Anywhere](https://www.realworkfromanywhere.com/)
 * [Authentic Jobs](https://authenticjobs.com/#onlyremote=1)
 * [FlexJobs](https://www.flexjobs.com/)
 * [NODESK](https://nodesk.co/remote-jobs/)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Notes:
 * [OkJob (4 day week jobs)](https://okjob.io/remote-4-day-work-week/)
 * [Real Work From Anywhere](https://www.realworkfromanywhere.com/)
 * [Remote4me](https://remote4me.com/)
-* [RemoteBase](https://remotebase.com/)
+* [Better Remote Jobs](https://betterremotejobs.com/)
 * [Remote.co](https://remote.co/remote-jobs/)
 * [Remote | OK](https://remoteok.io/)
 * [Remotive](http://jobs.remotive.io/)

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Notes:
 
 ## Remote job search websites
 
-* [Real Work From Anywhere](https://www.realworkfromanywhere.com/)
 * [Authentic Jobs](https://authenticjobs.com/#onlyremote=1)
 * [FlexJobs](https://www.flexjobs.com/)
 * [NODESK](https://nodesk.co/remote-jobs/)
 * [OkJob (4 day week jobs)](https://okjob.io/remote-4-day-work-week/)
+* [Real Work From Anywhere](https://www.realworkfromanywhere.com/)
 * [Remote4me](https://remote4me.com/)
 * [RemoteBase](https://remotebase.com/)
 * [Remote.co](https://remote.co/remote-jobs/)


### PR DESCRIPTION
<!--
Thank you for your contribution!
We love to see more remote companies, but we keep the list curated.
Please use the checklist to verify that the proposed company matches the current criteria.
-->

## Checklist

- [ ] The company has at least 50 employees.
- [ ] The company has multiple open positions that require programming skills.
- [ ] The company is hiring globally (i.e., not limited by timezone or to rich countries).
- [ ] Provide evidence for the above by including the company's LinkedIn page here: `<replace with LinkedIn page link>`.
- [X ] It is not a job aggregator site OR it has more traffic than existing sites.

Removed link: https://remotebase.com/

RemoteBase is not an aggregator, it is a hiring agency. Remote job seekers can't find any remote jobs on RemoteBase. So, I removed it with a better alternatives where users can actually find remote jobs.
